### PR TITLE
Added new ammo(27x145mm Mauser)

### DIFF
--- a/27x145mmMauser.xml
+++ b/27x145mmMauser.xml
@@ -1,0 +1,316 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<ThingCategoryDef>
+		<defName>Ammo27x145mmMauser</defName>
+		<label>27x145mm Mauser</label>
+		<parent>AmmoHighCaliber</parent>
+		<iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+	</ThingCategoryDef>
+
+	<!-- ==================== AmmoSet ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_27x145mmMauser</defName>
+		<label>27x145mm Mauser</label>
+		<ammoTypes>
+			<Ammo_27x145mmMauser_AP>Bullet_27x145mmMauser_AP</Ammo_27x145mmMauser_AP>
+			<Ammo_27x145mmMauser_HE>Bullet_27x145mmMauser_HE</Ammo_27x145mmMauser_HE>
+			<Ammo_27x145mmMauser_Incendiary>Bullet_27x145mmMauser_Incendiary</Ammo_27x145mmMauser_Incendiary>
+			<Ammo_27x145mmMauser_Sabot>Bullet_27x145mmMauser_Sabot</Ammo_27x145mmMauser_Sabot>
+		</ammoTypes>
+		<similarTo>AmmoSet_Autocannon</similarTo>
+	</CombatExtended.AmmoSetDef>
+
+	<!-- ==================== Ammo ========================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="Ammo27x145mmMauserBase" ParentName="MediumAmmoBase" Abstract="True">
+		<description>Large caliber cartridge used by autocannons.</description>
+		<statBases>
+			<Mass>0.6</Mass>
+			<Bulk>0.8</Bulk>
+		</statBases>
+		<tradeTags>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
+		</tradeTags>
+		<thingCategories>
+			<li>Ammo27x145mmMauser</li>
+		</thingCategories>
+		<stackLimit>250</stackLimit>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo27x145mmMauserBase">
+		<defName>Ammo_27x145mmMauser_AP</defName>
+		<label>27x145mm Mauser (AP)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/AP</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.17</MarketValue>
+		</statBases>
+		<ammoClass>ArmorPiercing</ammoClass>
+		<cookOffProjectile>Bullet_27x145mmMauser_AP</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo27x145mmMauserBase">
+		<defName>Ammo_27x145mmMauser_Incendiary</defName>
+		<label>27x145mm Mauser (AP-I)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Incendiary</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+			<drawSize>1.5</drawSize>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.57</MarketValue>
+			<Mass>0.52</Mass>
+		</statBases>
+		<ammoClass>IncendiaryAP</ammoClass>
+		<cookOffProjectile>Bullet_27x145mmMauser_Incendiary</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo27x145mmMauserBase">
+		<defName>Ammo_27x145mmMauser_HE</defName>
+		<label>27x145mm Mauser (AP-HE)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/HE</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>3.5</MarketValue>
+			<Mass>0.57</Mass>
+		</statBases>
+		<ammoClass>ExplosiveAP</ammoClass>
+		<cookOffProjectile>Bullet_27x145mmMauser_HE</cookOffProjectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo27x145mmMauserBase">
+		<defName>Ammo_27x145mm_Sabot</defName>
+		<label>27x145mm Mauser (Sabot)</label>
+		<graphicData>
+			<texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+			<graphicClass>Graphic_StackCount</graphicClass>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.08</MarketValue>
+			<Mass>0.51</Mass>
+		</statBases>
+		<ammoClass>Sabot</ammoClass>
+		<cookOffProjectile>Bullet_27x145mmMauser_Sabot</cookOffProjectile>
+	</ThingDef>
+
+	<!-- ================== Projectile ================== -->
+
+	<ThingDef Name="Base27x145mmMauserBullet" ParentName="BaseBulletCE" Abstract="true">
+	    <graphicData>
+			<texPath>Things/Projectile/Bullet_Big</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<speed>180</speed>
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Fleck_RifleAmmoCasings_HighCal</casingMoteDefname>
+			<casingFilthDefname>Filth_RifleAmmoCasings_HighCal</casingFilthDefname>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base27x145mmMauserBullet">
+		<defName>Bullet_27x145mmMauser_AP</defName>
+		<label>27x145mm Mauser bullet (AP)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>70</damageAmountBase>
+			<armorPenetrationSharp>64</armorPenetrationSharp>
+			<armorPenetrationBlunt>3428</armorPenetrationBlunt>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base27x145mmMauserBullet">
+		<defName>Bullet_27x145mmMauser_HE</defName>
+		<label>27x145mm Mauser bullet (AP-HE)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>181</speed>
+			<damageAmountBase>111</damageAmountBase>
+			<armorPenetrationSharp>57</armorPenetrationSharp>
+			<armorPenetrationBlunt>3428</armorPenetrationBlunt>
+		    <secondaryDamage>
+				<li>
+					<def>Bomb_Secondary</def>
+					<amount>51</amount>
+				</li>
+		    </secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base27x145mmMauserBullet">
+		<defName>Bullet_27x145mmMauser_Incendiary</defName>
+		<label>27x145mm Mauser bullet (AP-I)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<speed>181</speed>
+			<damageAmountBase>111</damageAmountBase>
+			<armorPenetrationSharp>48</armorPenetrationSharp>
+			<armorPenetrationBlunt>3428</armorPenetrationBlunt>
+		    <secondaryDamage>
+                <li>
+                  <def>Flame_Secondary</def>
+                   <amount>46</amount>
+                </li>
+	        </secondaryDamage>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef ParentName="Base27x145mmMauserBullet">
+		<defName>Bullet_27x145mmMauser_Sabot</defName>
+		<label>27x145mm Mauser bullet (Sabot)</label>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageAmountBase>54</damageAmountBase>
+			<armorPenetrationSharp>110</armorPenetrationSharp>
+			<armorPenetrationBlunt>4396.41</armorPenetrationBlunt>
+			<speed>235</speed>
+		</projectile>
+	</ThingDef>
+
+	<!-- ==================== Recipes ========================== -->
+
+	<RecipeDef ParentName="AmmoRecipeBase">
+		<defName>MakeAmmo_27x145mmMauser_AP</defName>
+		<label>make 27x145mm Mauser (AP) cartridge x200</label>
+		<description>Craft 200 27x145mm Mauser (AP) cartridges.</description>
+		<jobString>Making 27x145mm Mauser (AP) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>228</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_27x145mmMauser_AP>200</Ammo_27x145mmMauser_AP>
+		</products>
+		<workAmount>25440</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_27x145mmMauser_Incendiary</defName>
+		<label>make 27x145mm Mauser (AP-I) cartridge x200</label>
+		<description>Craft 200 27x145mm Mauser (AP-I) cartridges.</description>
+		<jobString>Making 27x145mm Mauser (AP-I) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>228</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Prometheum</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Prometheum</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_27x145mmMauser_Incendiary>50</Ammo_27x145mmMauser_Incendiary>
+		</products>
+		<workAmount>26040</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_27x145mmMauser_HE</defName>
+		<label>make 27x145mm Mauser (AP-HE) cartridge x200</label>
+		<description>Craft 200 27x145mm Mauser (AP-HE) cartridges.</description>
+		<jobString>Making 27x145mm Mauser (AP-HE) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>228</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>FSX</li>
+					</thingDefs>
+				</filter>
+				<count>36</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>FSX</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_27x145mmMauser_HE>200</Ammo_27x145mmMauser_HE>
+		</products>
+		<workAmount>35440</workAmount>
+	</RecipeDef>
+
+	<RecipeDef ParentName="AdvancedAmmoRecipeBase">
+		<defName>MakeAmmo_27x145mmMauser_Sabot</defName>
+		<label>make 27x145mm Mauser (Sabot) cartridge x200</label>
+		<description>Craft 200 27x145mm Mauser (Sabot) cartridges.</description>
+		<jobString>Making 27x145mm Mauser (Sabot) cartridges.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Steel</li>
+					</thingDefs>
+				</filter>
+				<count>132</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Uranium</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Chemfuel</li>
+					</thingDefs>
+				</filter>
+				<count>22</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Steel</li>
+				<li>Uranium</li>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Ammo_27x145mmMauser_Sabot>200</Ammo_27x145mmMauser_Sabot>
+		</products>
+		<workAmount>26640</workAmount>
+	</RecipeDef>
+
+</Defs>


### PR DESCRIPTION
Added new ammo(27x145mm Mauser) from reality, which is used on BK27, MLG27 and MIDAS.

## Additions   ## Changes

-Given that Combat Extended currently only has four types of cannon ammunition—AP, API, APHE, and Sabot—I have also only added these four types for the 27x145mm Mauser.


## Reasoning

-I submitted the 27x145mm Mauser ammunition to further expand the selection of realistic ammunition types in Combat Extended.


## Testing

- [x] Game runs without errors